### PR TITLE
Optional use of base dev container image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Project Base",
+  "image": "ghcr.io/jwbennet/project-base:latest",
+  "postCreateCommand": "task setup",
+}

--- a/.devcontainer/devcontainer.json.jinja
+++ b/.devcontainer/devcontainer.json.jinja
@@ -1,6 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 {
   "name": "{{project_name}}",
+  {%- if custom_devcontainer_features %}
   "image": "mcr.microsoft.com/devcontainers/base:jammy",
   "features": {
     "ghcr.io/devcontainers-contrib/features/copier": {
@@ -22,12 +23,13 @@
       "version": "3.12.1",
     },
   },
-
-  "postCreateCommand": "task setup",
-
   "customizations": {
     "vscode": {
       "extensions": ["EditorConfig.EditorConfig", "redhat.vscode-yaml"],
     },
   },
+  {%- else %}
+  "image": "ghcr.io/jwbennet/project-base:latest",
+  {%- endif %}
+  "postCreateCommand": "task setup"
 }

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+  "name": "Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/copier": {
+      "version": "9.1.1",
+    },
+    "ghcr.io/devcontainers-contrib/features/go-task": {
+      "version": "3.33.1",
+    },
+    "ghcr.io/devcontainers-contrib/features/mkdocs": {
+      "version": "1.5.3",
+    },
+    "ghcr.io/devcontainers/features/node": {
+      "version": "20.11.0",
+    },
+    "ghcr.io/devcontainers-contrib/features/pre-commit": {
+      "version": "3.6.0",
+    },
+    "ghcr.io/devcontainers/features/python": {
+      "version": "3.12.1",
+    },
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": ["EditorConfig.EditorConfig", "redhat.vscode-yaml"],
+    },
+  },
+}

--- a/.github/.devcontainer/workflows/devcontainer-build-and-push.yaml
+++ b/.github/.devcontainer/workflows/devcontainer-build-and-push.yaml
@@ -1,0 +1,32 @@
+name: Dev Container Build and Push Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+    pull_requests:
+      branches:
+        - "main"
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-build dev container image
+        uses: devcontainers/ci@v0.2
+        with:
+          subFolder: .github
+          imageName: ghcr.io/${{ github.repository }}
+          cacheFrom: ghcr.io/${{ github.repository }}
+          push: always

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -7,9 +7,6 @@ on:
       - "main"
     tags:
       - "v*.*.*"
-    pull_requests:
-      branches:
-        - "main"
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/copier.yaml
+++ b/copier.yaml
@@ -2,6 +2,10 @@
 project_name:
   type: str
   help: Enter your project name.
+custom_devcontainer_features:
+  type: bool
+  help: Utilize custom features in the devcontainer?
+  default: false
 
 # Copier config
 _exclude:
@@ -16,6 +20,7 @@ _exclude:
   - ".svn"
   # Add custom files to ignore
   - .dockerignore
+  - .github
   - docker-entrypoint.sh
   - Dockerfile
   - LICENSE


### PR DESCRIPTION
Provides the ability to use the project base dev container as the base for the project. If the user opts out using copier then they will be provided a `devcontainer.json` with the default features available so they may customize.