### PR TITLE
Only build dev container when updated

### DIFF
--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -7,6 +7,8 @@ on:
       - "main"
     tags:
       - "v*.*.*"
+    paths:
+      - .github/.devcontainer
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes the GitHub Actions workflow which builds the base dev container image so it will only build when changes are made to files in the `.github/.devcontainer` path.