### PR TITLE
Initial GitHub Actions support

### DIFF
--- a/.devcontainer/devcontainer.json.jinja
+++ b/.devcontainer/devcontainer.json.jinja
@@ -1,35 +1,6 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 {
   "name": "{{project_name}}",
-  {%- if custom_devcontainer_features %}
-  "image": "mcr.microsoft.com/devcontainers/base:jammy",
-  "features": {
-    "ghcr.io/devcontainers-contrib/features/copier": {
-      "version": "9.1.1",
-    },
-    "ghcr.io/devcontainers-contrib/features/go-task": {
-      "version": "3.33.1",
-    },
-    "ghcr.io/devcontainers-contrib/features/mkdocs": {
-      "version": "1.5.3",
-    },
-    "ghcr.io/devcontainers/features/node": {
-      "version": "20.11.0",
-    },
-    "ghcr.io/devcontainers-contrib/features/pre-commit": {
-      "version": "3.6.0",
-    },
-    "ghcr.io/devcontainers/features/python": {
-      "version": "3.12.1",
-    },
-  },
-  "customizations": {
-    "vscode": {
-      "extensions": ["EditorConfig.EditorConfig", "redhat.vscode-yaml"],
-    },
-  },
-  {%- else %}
-  "image": "ghcr.io/jwbennet/project-base:latest",
-  {%- endif %}
+  "image": "{{devcontainer_image}}",
   "postCreateCommand": "task setup"
 }

--- a/copier.yaml
+++ b/copier.yaml
@@ -6,6 +6,25 @@ custom_devcontainer_features:
   type: bool
   help: Utilize custom features in the devcontainer?
   default: false
+git_provider:
+  type: str
+  help: Which Git provider would you like to use?
+  choices:
+    GitHub: github
+  default: github
+github_organization:
+  type: str
+  help: Enter the name of the GitHub organization/user.
+  when: "{{ git_provider == 'github' }}"
+github_repository:
+  type: str
+  help: Enter the name of your GitHub repository.
+  default: "{{ github_organization }}/{{ project_name | lower | replace(' ', '-') }}"
+  when: "{{ git_provider == 'github' }}"
+devcontainer_image:
+  type: str
+  help: Enter the name of your devcontainer image.
+  default: "{% if git_provider == 'github' %}ghcr.io/{{github_repository}}:latest{% else %}{% endif %}"
 
 # Copier config
 _exclude:

--- a/{% if git_provider == 'github' %}.github{% endif %}/.devcontainer/devcontainer.json.jinja
+++ b/{% if git_provider == 'github' %}.github{% endif %}/.devcontainer/devcontainer.json.jinja
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+  "name": "{{project_name}}",
+  {%- if custom_devcontainer_features %}
+  "image": "mcr.microsoft.com/devcontainers/base:jammy",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/copier": {
+      "version": "9.1.1"
+    },
+    "ghcr.io/devcontainers-contrib/features/go-task": {
+      "version": "3.33.1"
+    },
+    "ghcr.io/devcontainers-contrib/features/mkdocs": {
+      "version": "1.5.3"
+    },
+    "ghcr.io/devcontainers/features/node": {
+      "version": "20.11.0"
+    },
+    "ghcr.io/devcontainers-contrib/features/pre-commit": {
+      "version": "3.6.0"
+    },
+    "ghcr.io/devcontainers/features/python": {
+      "version": "3.12.1"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["EditorConfig.EditorConfig", "redhat.vscode-yaml"],
+      "settings": {
+        "files.associations": {
+          ".commitlintrc": "yaml",
+          ".lintstagedrc": "yaml",
+          ".prettierrc": "yaml"
+        }
+      }
+    }
+  }
+  {%- else %}
+  "image": "ghcr.io/jwbennet/project-base:latest"
+  {%- endif %}
+}

--- a/{% if git_provider == 'github' %}.github{% endif %}/workflows/devcontainer-build-and-push.yaml.jinja
+++ b/{% if git_provider == 'github' %}.github{% endif %}/workflows/devcontainer-build-and-push.yaml.jinja
@@ -1,0 +1,31 @@
+name: Dev Container Build and Push Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+    paths:
+      - .github/.devcontainer/**
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: "{% raw %}${{ github.actor }}{% endraw %}"
+          password: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
+      - name: Pre-build dev container image
+        uses: devcontainers/ci@v0.2
+        with:
+          subFolder: .github
+          imageName: "{% raw %}ghcr.io/${{ github.repository }}{% endraw %}"
+          cacheFrom: "{% raw %}ghcr.io/${{ github.repository }}{% endraw %}"
+          push: always


### PR DESCRIPTION
Extended the copier questions to inquire about which Git provider is used. When GitHub is used the project is generated with a starter GitHub Actions structure for managing the dev container.