### PR TITLE
Syntax highlighting for Jinja2 files

### DIFF
--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -26,7 +26,11 @@
 
   "customizations": {
     "vscode": {
-      "extensions": ["EditorConfig.EditorConfig", "redhat.vscode-yaml"],
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "redhat.vscode-yaml",
+        "samuelcolvin.jinjahtml"
+      ],
       "settings": {
         "files.associations": {
           ".commitlintrc": "yaml",


### PR DESCRIPTION
Adds a VSCode extension to the base dev container which provides syntax highlighting for Jinja2 templates. This is only used in the dev container for the project-base file since downstream projects may or may not use Jinja2.