### PR TITLE
Remove constraint on container metadata step

### DIFF
--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -24,7 +24,6 @@ jobs:
       - name: Extract tags for Docker image
         id: meta
         uses: docker/metadata-action@v5
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           flavor: |
             latest=false


### PR DESCRIPTION
The step in the dev container build process which pulls metadata to generate a set of tags should not be skipped on main. The original intention was to use a separate process for tagging builds from main, but that can be merged into the metadata step so it should not be skipped.