### PR TITLE
ci: join dev container tags

### DIFF
--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -37,6 +37,6 @@ jobs:
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}
-          imageTag: ${{ steps.meta.outputs.tags }}
+          imageTag: ${{ join(steps.meta.outputs.tags) }}
           cacheFrom: ghcr.io/${{ github.repository }}
           push: always


### PR DESCRIPTION
The output of the docker/metadata-action returns the tags to apply with newlines instead of commas so using the join function to join them with commas (the default separator).